### PR TITLE
chore: update docs for ui_locales param in sso callback url

### DIFF
--- a/customer_portal_jwt_sso_login/README.md
+++ b/customer_portal_jwt_sso_login/README.md
@@ -29,8 +29,23 @@ policies across their applications on DevRev.
    this format for the URL:
    `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>`
 
-6. **Custom Redirects**: The above redirection URL will take the user to the default landing page of your customer portal. If you need custom redirection, use the `redirect_to` param. This param accepts a relative path after your slug and will redirect the user to the specified path post login. 
-Example: `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&redirect_to=/article/ART-1` will login the user and redirect them to  `http://support.devrev.ai/<your-org-slug>/article/ART-1` post login.
+6. **Custom Redirects**: The above redirection URL will take the user to the default landing page of your customer portal. If you need custom redirection, use the `redirect_to` param. This param accepts a relative path after your slug and will redirect the user to the specified path post login.
+   Example: `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&redirect_to=/article/ART-1` will login the user and redirect them to `http://support.devrev.ai/<your-org-slug>/article/ART-1` post login.
+
+7. **Preferred UI Locale**: To render the customer portal in a specific language for the user, use the `ui_locales` param. This param accepts a single locale tag in [BCP-47](https://www.rfc-editor.org/info/bcp47) format (e.g., `en-US`, `fr-FR`, `ja-JP`, `pt-BR`, `zh-Hans`) and sets the portal's UI language for the session initiated by this SSO redirect.
+
+   Example: `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&ui_locales=fr-FR` will log the user in and render the customer portal in French.
+
+   `ui_locales` can be combined with `redirect_to`, for example:
+   `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&redirect_to=/article/ART-1&ui_locales=ja-JP`
+
+    > **Note:** Before the portal can honor a locale passed via `ui_locales`, it must be enabled in two places:
+    >
+    > 1. **Add the language** to your portal's supported languages from **Settings → Language and Region → Portal Supported Languages**.
+    >
+    > 2. **Publish the language** from **Portal Settings**.
+    >
+    > Until both steps are completed, the locale will be ignored and the portal will fall back to the default locale configured in portal settings. The same applies to any unsupported or malformed BCP-47 tag.
 
 ## The Onetime Token 🛡️
 

--- a/customer_portal_jwt_sso_login/README.md
+++ b/customer_portal_jwt_sso_login/README.md
@@ -32,7 +32,7 @@ policies across their applications on DevRev.
 6. **Custom Redirects**: The above redirection URL will take the user to the default landing page of your customer portal. If you need custom redirection, use the `redirect_to` param. This param accepts a relative path after your slug and will redirect the user to the specified path post login.
    Example: `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&redirect_to=/article/ART-1` will login the user and redirect them to `http://support.devrev.ai/<your-org-slug>/article/ART-1` post login.
 
-7. **Preferred UI Locale**: To render the customer portal in a specific language for the user, use the `ui_locales` param. This param accepts a single locale tag in [BCP-47](https://www.rfc-editor.org/info/bcp47) format (e.g., `en-US`, `fr-FR`, `ja-JP`, `pt-BR`, `zh-Hans`) and sets the portal's UI language for the session initiated by this SSO redirect.
+7. **Preferred UI Locale**: To render the customer portal in a specific language for the user, use the `ui_locales` param. This param accepts a single locale tag in [BCP-47](https://www.rfc-editor.org/info/bcp47) format (e.g., `en-US`, `fr-FR`, `ja-JP`, `pt-BR`) and sets the portal's UI language for the session initiated by this SSO redirect.
 
    Example: `http://support.devrev.ai/<your-org-slug>/callback/sso?jwt=<onetime-token>&ui_locales=fr-FR` will log the user in and render the customer portal in French.
 


### PR DESCRIPTION
## Summary

Adds support for a ui_locales query param on the SSO callback URL so the portal can be rendered in a specific language for the incoming session. The param accepts a [BCP-47](https://www.rfc-editor.org/info/bcp47) locale tag (e.g., en-US, fr-FR, ja-JP) and works alongside the existing redirect_to param — e.g. …/callback/sso?jwt=<token>&redirect_to=/article/ART-1&ui_locales=ja-JP.

The locale only takes effect if it has been added under Settings → Language and Region → Portal Supported Languages and then published from Portal Settings. Unsupported or unpublished tags are ignored and the portal falls back to its default locale, so existing SSO flows are unaffected. The SSO setup doc is updated with the new param and prerequisites.

## Connected Issues
- Work Item :- https://app.devrev.ai/devrev/issue/PORT-27

## Craftsmanship, Integrity, and Devil’s Advocacy
<!-- Mark the appropriate option with an "x" -->
- [ ] Testing: Negative test cases: null or default values, crash and fault injection tests
- [ ] Testing: Boundary conditions: rolling upgrades, denial-of-service, etc.
- [ ] Testing: Fixing a few existing — flaky or permanently-broken — test cases
- [ ] Observing: Detailed error codes so machines can understand
- [ ] Observing: Adding superior metrics for future debugging
- [ ] Observing: Tracing the hairiest pathways for field serviceability
- [ ] Training: KnowledgeOps update? So AI always works.